### PR TITLE
Allow installation with symfony/string ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         "symfony/console": "^5.0|^6.0|^7.0",
         "symfony/finder": "^5.0|^6.0|^7.0",
         "symfony/filesystem": "^5.0|^6.0|^7.0",
+        "symfony/string": "^5.1|^6.0|^7.0",
         "cucumber/gherkin": "^24.0",
         "cucumber/messages": "^19.0",
-        "symfony/string": "^5.1|^6.0",
         "dantleech/invoke": "^2.0"
     },
     "license": "MIT",


### PR DESCRIPTION
This PR allows installation with symfony/string ^7.0 making this package fully compatible with Symfony 7 projects.