### PR TITLE
feat: add Symfony 8.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/console": "^5.0|^6.0|^7.0",
-        "symfony/finder": "^5.0|^6.0|^7.0",
-        "symfony/filesystem": "^5.0|^6.0|^7.0",
-        "symfony/string": "^5.1|^6.0|^7.0",
+        "symfony/console": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/finder": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/filesystem": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/string": "^5.1|^6.0|^7.0|^8.0",
         "cucumber/gherkin": "^24.0",
         "cucumber/messages": "^19.0",
         "dantleech/invoke": "^2.0"
@@ -34,8 +34,8 @@
     ],
     "minimum-stability": "stable",
     "require-dev": {
-        "symfony/var-dumper": "^6.0",
-        "symfony/process": "^6.0",
+        "symfony/var-dumper": "^6.0|^7.0|^8.0",
+        "symfony/process": "^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^10.5",
         "vimeo/psalm": "^5.22",
         "friendsofphp/php-cs-fixer": "^3.8"


### PR DESCRIPTION
## Summary
- Add `^8.0` to all Symfony dependency constraints (`console`, `finder`, `filesystem`, `string`, `var-dumper`, `process`)
- Also added missing `^7.0` to `var-dumper` and `process` dev dependencies

## Test plan
- [x] All 134 existing tests pass (175 assertions)
- [x] `composer update` resolves successfully with the updated constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)